### PR TITLE
Fix bst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,10 +889,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2377,7 +2375,8 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "log",
- "rand 0.7.3",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rendiation-abstract-tree",
  "rendiation-algebra",
  "rendiation-geometry",

--- a/components/space/Cargo.toml
+++ b/components/space/Cargo.toml
@@ -18,4 +18,5 @@ rendiation-algebra = {path = "../../math/algebra"}
 rendiation-geometry = {path = "../../math/geometry"}
 
 log = "0.4"
-rand = {version = "0.7.3", features = ["wasm-bindgen"]}
+rand = "0.8.5"
+rand_chacha = "0.3.1"

--- a/components/space/src/bst/apply.rs
+++ b/components/space/src/bst/apply.rs
@@ -1,6 +1,6 @@
 use super::{BSTBounding, BSTTree, BinarySpaceTree};
 use crate::utils::BuildPrimitive;
-use rendiation_algebra::Vec3;
+use rendiation_algebra::vec3;
 use rendiation_geometry::Box3;
 
 pub type BinaryTree = BSTTree<Binary, 2, 1>;
@@ -21,15 +21,13 @@ impl BSTBounding<3, 8> for Box3 {
     i
   }
 
+  #[rustfmt::skip]
   fn compute_sub_space(&self, i: usize) -> Self {
     let center = self.center();
-    let half_size = self.half_size();
-    let x_dir = if i % 2 < 1 { 1.0 } else { -1.0 };
-    let y_dir = if i % 4 < 2 { 1.0 } else { -1.0 };
-    let z_dir = if i < 4 { 1.0 } else { -1.0 };
-
-    let child_center = center + half_size * Vec3::new(x_dir, y_dir, z_dir);
-    Box3::new_from_center(child_center, half_size * 0.5)
+    let (x_min, x_max) = if i & 1 > 0 { (center.x, self.max.x) } else { (self.min.x, center.x) };
+    let (y_min, y_max) = if i & 2 > 0 { (center.y, self.max.y) } else { (self.min.y, center.y) };
+    let (z_min, z_max) = if i & 4 > 0 { (center.z, self.max.z) } else { (self.min.z, center.z) };
+    Box3::new(vec3(x_min, y_min, z_min), vec3(x_max, y_max, z_max))
   }
 }
 

--- a/components/space/src/bst/mod.rs
+++ b/components/space/src/bst/mod.rs
@@ -114,6 +114,16 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTreeBuilder<T,
   }
   fn apply_index_source(&mut self, index_source: &mut [usize], range: Range<usize>) {
     let mut start = range.start;
+
+    {
+      let mut count = 0;
+      self.crossed.iter().for_each(|&i| {
+        index_source[start + count] = i;
+        count += 1;
+      });
+      start += count;
+    }
+
     let ranges = &mut self.ranges;
     self
       .partitions
@@ -127,8 +137,7 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTreeBuilder<T,
         });
         ranges[index] = start..start + count;
         start += count;
-      })
-    // TODO write crossed indices to index_source
+      });
   }
 }
 
@@ -199,18 +208,16 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTree<T, N, D> 
       builder.apply_index_source(index_source, node.primitive_range.clone());
       (node_index, node.depth)
     };
-    let boundings = builder.bounding.clone();
+    let bounding = builder.bounding.clone();
     let ranges = builder.ranges.clone();
     // builder should not be used any more
-
-    // TODO skip child creation if all partitions are empty? (all crossed)
 
     let mut child = [0; N];
     for (i, range) in ranges.iter().enumerate() {
       let child_index = nodes.len();
       nodes.push(BSTNode {
         phantom: PhantomData,
-        bounding: boundings[i],
+        bounding: bounding[i],
         primitive_range: range.clone(),
         depth: depth + 1,
         self_index: child_index,

--- a/components/space/src/bst/mod.rs
+++ b/components/space/src/bst/mod.rs
@@ -128,6 +128,7 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTreeBuilder<T,
         ranges[index] = start..start + count;
         start += count;
       })
+    // TODO write crossed indices to index_source
   }
 }
 
@@ -179,13 +180,13 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTree<T, N, D> 
     index_source: &mut Vec<usize>,
     nodes: &mut Vec<BSTNode<T, N, D>>,
     builder: &mut BSTTreeBuilder<T, N, D>,
-  ) -> usize {
+  ) {
     let (node_index, depth) = {
       let node_index = nodes.len() - 1;
       let node = nodes.last_mut().unwrap();
 
       if !option.should_continue(node.primitive_range.len(), node.depth) {
-        return 1;
+        return;
       }
 
       builder.reset(node.bounding);
@@ -198,23 +199,26 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTree<T, N, D> 
       builder.apply_index_source(index_source, node.primitive_range.clone());
       (node_index, node.depth)
     };
+    let boundings = builder.bounding.clone();
+    let ranges = builder.ranges.clone();
+    // builder should not be used any more
+
+    // TODO skip child creation if all partitions are empty? (all crossed)
 
     let mut child = [0; N];
-    let mut offset = 1;
-    let ranges = builder.ranges.clone();
     for (i, range) in ranges.iter().enumerate() {
+      let child_index = nodes.len();
       nodes.push(BSTNode {
         phantom: PhantomData,
-        bounding: builder.bounding[i],
+        bounding: boundings[i],
         primitive_range: range.clone(),
         depth: depth + 1,
-        self_index: nodes.len(),
+        self_index: child_index,
         child: None,
       });
-      child[i] = offset;
-      offset += Self::build(option, build_source, index_source, nodes, builder);
+      child[i] = child_index;
+      Self::build(option, build_source, index_source, nodes, builder);
     }
     nodes[node_index].child = Some(child);
-    offset
   }
 }

--- a/components/space/src/bst/mod.rs
+++ b/components/space/src/bst/mod.rs
@@ -210,7 +210,6 @@ impl<T: BinarySpaceTree<D, N>, const N: usize, const D: usize> BSTTree<T, N, D> 
     };
     let bounding = builder.bounding.clone();
     let ranges = builder.ranges.clone();
-    // builder should not be used any more
 
     let mut child = [0; N];
     for (i, range) in ranges.iter().enumerate() {

--- a/components/space/src/bst/test.rs
+++ b/components/space/src/bst/test.rs
@@ -4,6 +4,8 @@ use crate::bst::{BSTTreeNodeRef, Oc};
 use rendiation_abstract_tree::AbstractTree;
 #[cfg(test)]
 use std::collections::HashSet;
+#[cfg(test)]
+use std::ops::Range;
 
 #[cfg(test)]
 fn print(prefix: &String, name: String, node: &BSTTreeNodeRef<Oc, 8, 3>) {
@@ -67,8 +69,18 @@ pub fn test_bst_build() {
   let root = tree.create_node_ref(0);
   visit(&"".into(), "root".into(), true, &root);
 
-  //TODO test tree
+  // test tree
+  assert!(root.node.child.is_some());
+  let mut ranges = Vec::<Range<usize>>::new();
+  root.visit_children(|child| {
+    ranges.push(child.node.primitive_range.clone());
+  });
+  assert_eq!(
+    ranges,
+    vec!(1..1, 1..4, 4..12, 12..15, 15..20, 20..23, 23..27, 27..32)
+  );
 
+  // sorted_primitive_index not corrupted
   assert_eq!(
     COUNT,
     HashSet::<usize>::from_iter(tree.sorted_primitive_index.iter().cloned()).len()

--- a/components/space/src/bst/test.rs
+++ b/components/space/src/bst/test.rs
@@ -1,7 +1,75 @@
+#[cfg(test)]
+use crate::bst::{BSTTreeNodeRef, Oc};
+#[cfg(test)]
+use rendiation_abstract_tree::AbstractTree;
+#[cfg(test)]
+use std::collections::HashSet;
+
+#[cfg(test)]
+fn print(prefix: &String, name: String, node: &BSTTreeNodeRef<Oc, 8, 3>) {
+  if node.node.primitive_range.len() > 0 {
+    println!(
+      "{}+- {}, primitive_index range [{}, {})",
+      prefix, name, node.node.primitive_range.start, node.node.primitive_range.end,
+    );
+  } else {
+    println!("{}+- {}, empty", prefix, name);
+  }
+}
+
+#[cfg(test)]
+fn print_crossed(prefix: &String, node: &BSTTreeNodeRef<Oc, 8, 3>, end: usize) {
+  println!(
+    "{}+- crossed, primitive_index range [{}, {})",
+    prefix, node.node.primitive_range.start, end,
+  );
+}
+
+#[cfg(test)]
+fn visit(prefix: &String, name: String, is_last: bool, node: &BSTTreeNodeRef<Oc, 8, 3>) {
+  print(prefix, name, node);
+  let child_prefix = if !is_last {
+    format!("{}|  ", prefix)
+  } else {
+    format!("{}   ", prefix)
+  };
+
+  let mut index: usize = 0;
+  let child_count = node.children_count();
+
+  node.visit_children(|child| {
+    if index == 0 && child.node.primitive_range.start > node.node.primitive_range.start {
+      print_crossed(&child_prefix, node, node.node.primitive_range.start + 1);
+    }
+
+    let is_last = child_count == index + 1;
+    visit(&child_prefix, format!("child {}", index), is_last, child);
+
+    index += 1;
+  });
+}
+
 #[test]
-pub fn test_bvh_build() {
+pub fn test_bst_build() {
   use super::OcTree;
   use crate::utils::*;
-  let boxes = generate_boxes_in_space(32, 1000., 1.);
-  let _ = OcTree::new(boxes.iter().cloned(), &TreeBuildOption::default());
+
+  const COUNT: usize = 32;
+  let boxes = generate_boxes_in_space(COUNT, 100., 1.);
+  let tree = OcTree::new(
+    boxes.iter().cloned(),
+    &TreeBuildOption {
+      bin_size: 4,
+      max_tree_depth: 10,
+    },
+  );
+
+  let root = tree.create_node_ref(0);
+  visit(&"".into(), "root".into(), true, &root);
+  //TODO verify tree
+
+  assert_eq!(
+    COUNT,
+    HashSet::<usize>::from_iter(tree.sorted_primitive_index.iter().cloned()).len()
+  )
 }

--- a/components/space/src/bst/test.rs
+++ b/components/space/src/bst/test.rs
@@ -66,10 +66,11 @@ pub fn test_bst_build() {
 
   let root = tree.create_node_ref(0);
   visit(&"".into(), "root".into(), true, &root);
-  //TODO verify tree
+
+  //TODO test tree
 
   assert_eq!(
     COUNT,
     HashSet::<usize>::from_iter(tree.sorted_primitive_index.iter().cloned()).len()
-  )
+  );
 }

--- a/components/space/src/utils.rs
+++ b/components/space/src/utils.rs
@@ -1,6 +1,5 @@
 use std::{iter::FromIterator, ops::Range};
 
-use rand::random;
 use rendiation_algebra::Vec3;
 use rendiation_geometry::Box3;
 
@@ -67,6 +66,13 @@ where
 }
 
 pub fn generate_boxes_in_space(count: usize, space_size: f32, box_size: f32) -> Vec<Box3> {
+  use rand::prelude::*;
+  use rand_chacha::ChaCha8Rng;
+
+  const SEED: u64 = 0x6246A426A2424AC + 0x1;
+  let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+  let mut random = || rng.gen::<f32>();
+
   (0..count)
     .into_iter()
     .map(|_| {


### PR DESCRIPTION
fix bst:
- fix compute_sub_space: fix subspace size, reuse numbers to fix f32 precision loss (fix https://github.com/mikialex/rendiation/issues/98)
- fix build: copy bounds before child resets builder
- fix build: fix child indices for visit_children
- fix apply_index_source: save crossed children at the start of parent range (**Is this the approach you intend to take?**)
- test: print tree in test.rs (including "crossed" children), check for duplicates in sorted_primitive_index
- test: use rand_chacha for reproducible test
- test tree