### PR TITLE
fix normal

### DIFF
--- a/scene/webgpu/src/node.rs
+++ b/scene/webgpu/src/node.rs
@@ -75,7 +75,7 @@ impl ShaderGraphProvider for TransformGPU {
       builder.register::<WorldVertexPosition>(position.xyz());
 
       let normal = builder.query::<GeometryNormal>()?;
-      builder.register::<WorldVertexNormal>((model.normal_matrix * normal).normalize());
+      builder.register::<WorldVertexNormal>(model.normal_matrix * normal);
       Ok(())
     })
   }

--- a/scene/webgpu/src/rendering/forward.rs
+++ b/scene/webgpu/src/rendering/forward.rs
@@ -191,7 +191,8 @@ impl ForwardLightingSystem {
       let position =
         builder.query_or_interpolate_by::<FragmentWorldPosition, WorldVertexPosition>();
       let normal = builder.query_or_interpolate_by::<FragmentWorldNormal, WorldVertexNormal>();
-      builder.register::<FragmentWorldNormal>(normal.normalize()); // renormalize
+      let normal = normal.normalize(); // renormalize
+      builder.register::<FragmentWorldNormal>(normal);
 
       // debug
       // let normal = compute_normal_by_dxdy(position);


### PR DESCRIPTION
[ShaderLightingGeometricCtx did not use renormalized vector.](https://github.com/mikialex/rendiation/blob/0ea8615e6ee83b3b51287d683c2fcb9c7cdec67f/scene/webgpu/src/rendering/forward.rs#L203)

revert https://github.com/mikialex/rendiation/pull/135 and fix it correctly.